### PR TITLE
Change compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-  compile 'net.kyori:adventure-text-minimessage:3.0.0-SNAPSHOT'
+  implementation 'net.kyori:adventure-text-minimessage:3.0.0-SNAPSHOT'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Simple library that implements an easy to use textual format on top of component
 
 * Maven
 ```xml
+<repository>
+  <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+</repository>
+
 <dependency>
   <groupId>net.kyori</groupId>
   <artifactId>adventure-text-minimessage</artifactId>
@@ -19,7 +23,9 @@ Simple library that implements an easy to use textual format on top of component
 * Gradle
 ```gradle
 repositories {
-  mavenCentral()
+  maven {
+    url = 'https://oss.sonatype.org/content/repositories/snapshots'
+  }
 }
 
 dependencies {


### PR DESCRIPTION
compile is deprecated, it's use shouldn't be encouraged. also changed the repo to sonatype, since adventure isn't currently hosted on central.