### PR TITLE
Improve tag escape handling ( #45 )

### DIFF
--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.minimessage;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -116,6 +117,23 @@ public class MiniMessageParserTest {
     assertEquals(expected, MiniMessageParser.escapeTokens(input));
   }
 
+  @Test
+  public void testUnescape() {
+    final String input ="<yellow>TEST\\<green\\> nested\\</green\\>Test";
+    final String expected = "TEST<green> nested</green>Test";
+    TextComponent comp = (TextComponent) MiniMessageParser.parseFormat(input);
+
+    assertEquals(expected, comp.content());
+  }
+
+  @Test
+  public void testNoUnescape() {
+    final String input ="<yellow>TEST\\<green\\>\\> \\< nested\\</green\\>Test";
+    final String expected = "TEST<green>\\> \\< nested</green>Test";
+    TextComponent comp = (TextComponent) MiniMessageParser.parseFormat(input);
+
+    assertEquals(expected, comp.content());
+  }
 
   @Test
   public void checkPlaceholder() {


### PR DESCRIPTION
Attempts to handle escaped tags better for #45.

Things it does in order of appearance in diff:
* Detect the backslashes in an escaped tag separately in the regex
  * Previously would ignore the first backslash and include the second one (inside) as part of the tag, e.g. `\<red\>` would be interpreted as a tag `red\`
* No longer double escapes if an escaped tag shows up in the escape method.
  * e.g. `\<red\>` will not become `\\<red\\>`
* No longer strips escaped tags
* No longer tries (and then fails) to process escaped tag
* Strips the escaping in the final message.
  * One small problem, this replacing does not care if it was part of an escaped tag and just replaces `\<` with `<` and `\>` with `>` no matter where they are in the message text, so this would catch more than just escaped stuff. Open to suggestions on fixing this without adding some additional expensive regexing, which I wanted to avoid with this.