### PR TITLE
Fix parsing click events with quotation marks

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -557,7 +557,11 @@ import static net.kyori.adventure.text.minimessage.Tokens.FONT;
     }
     final ClickEvent.Action action = ClickEvent.Action.NAMES.value(args[1].toLowerCase(Locale.ROOT));
     if (action == null) throw new ParseException("Can't parse click action (invalid action) " + token);
-    return ClickEvent.clickEvent(action, token.replace(CLICK + SEPARATOR + args[1] + SEPARATOR, ""));
+    String value = token.replace(CLICK + SEPARATOR + args[1] + SEPARATOR, "");
+    if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith("\"") && value.endsWith("\""))) {
+      value = value.substring(1, value.length() - 1);
+    }
+    return ClickEvent.clickEvent(action, value);
   }
 
 

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -326,6 +326,19 @@ public class MiniMessageParserTest {
   }
 
   @Test
+  public void testGH5Quoted() {
+    final String input = "<dark_gray>»<gray> To download it from the internet, <click:open_url:\"https://www.google.com\"><hover:show_text:\"<green>/!\\ install it from Options/ResourcePacks in your game\"><green><bold>CLICK HERE</bold></hover></click>";
+    final String expected = "{\"text\":\"\",\"extra\":[{\"text\":\"»\",\"color\":\"dark_gray\"},{\"text\":\" To download it from the internet, \",\"color\":\"gray\"},{\"text\":\"CLICK HERE\",\"color\":\"green\",\"bold\":true,\"clickEvent\":{\"action\":\"open_url\",\"value\":\"https://www.google.com\"},\"hoverEvent\":{\"action\":\"show_text\",\"contents\":{\"text\":\"/!\\\\ install it from Options/ResourcePacks in your game\",\"color\":\"green\"}}}]}";
+
+    // should work
+    final Component comp1 = MiniMessageParser.parseFormat(input);
+    test(comp1, expected);
+
+    // shouldnt throw an error
+    MiniMessageParser.parseFormat(input, "url", "https://www.google.com");
+  }
+
+  @Test
   @Disabled("Need to implement inner with ' or \"")  // TODO
   public void testGH5Modified() {
     final String input = "<dark_gray>»<gray> To download it from the internet, <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ install it from 'Options/ResourcePacks' in your game\"><green><bold>CLICK HERE</bold></hover></click>";


### PR DESCRIPTION
Without this change, (single/double) quotation marks will stay in the click event value when used in the format.
Which causes the client to ignore the event entirely, as if it wasn't applied to the component(s).

This PR solves that by manually checking for the quotation marks and removing them before creating the click event.