### PR TITLE
Use a Consumer<List<String>> instead of a Consumer<String> for error messages

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -294,7 +294,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @return this builder
      * @since 4.1.0
      */
-    @NonNull Builder parsingErrorMessageConsumer(final Consumer<String> consumer);
+    @NonNull Builder parsingErrorMessageConsumer(final Consumer<List<String>> consumer);
 
     /**
      * Builds the serializer.

--- a/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 public class MiniMessageImpl implements MiniMessage {
 
   static final Function<String, ComponentLike> DEFAULT_PLACEHOLDER_RESOLVER = s -> null;
-  static final Consumer<String> DEFAULT_ERROR_CONSUMER = System.out::println;
+  static final Consumer<List<String>> DEFAULT_ERROR_CONSUMER = message -> message.forEach(System.out::println);
 
   static final MiniMessage INSTANCE = new MiniMessageImpl(false, MarkdownFlavor.defaultFlavor(), new TransformationRegistry(), DEFAULT_PLACEHOLDER_RESOLVER, false, DEFAULT_ERROR_CONSUMER);
   static final MiniMessage MARKDOWN = new MiniMessageImpl(true, MarkdownFlavor.defaultFlavor(), new TransformationRegistry(), DEFAULT_PLACEHOLDER_RESOLVER, false, DEFAULT_ERROR_CONSUMER);
@@ -55,9 +55,9 @@ public class MiniMessageImpl implements MiniMessage {
   private final MarkdownFlavor markdownFlavor;
   private final MiniMessageParser parser;
   private final boolean strict;
-  private final Consumer<String> parsingErrorMessageConsumer;
+  private final Consumer<List<String>> parsingErrorMessageConsumer;
 
-  MiniMessageImpl(final boolean markdown, final @NonNull MarkdownFlavor markdownFlavor, final @NonNull TransformationRegistry registry, final @NonNull Function<String, ComponentLike> placeholderResolver, final boolean strict, final @NonNull Consumer<String> parsingErrorMessageConsumer) {
+  MiniMessageImpl(final boolean markdown, final @NonNull MarkdownFlavor markdownFlavor, final @NonNull TransformationRegistry registry, final @NonNull Function<String, ComponentLike> placeholderResolver, final boolean strict, final @NonNull Consumer<List<String>> parsingErrorMessageConsumer) {
     this.markdown = markdown;
     this.markdownFlavor = markdownFlavor;
     this.parser = new MiniMessageParser(registry, placeholderResolver);
@@ -157,7 +157,7 @@ public class MiniMessageImpl implements MiniMessage {
    * @return huhu.
    * @since 4.1.0
    */
-  public @NonNull Consumer<String> parsingErrorMessageConsumer() {
+  public @NonNull Consumer<List<String>> parsingErrorMessageConsumer() {
     return this.parsingErrorMessageConsumer;
   }
 
@@ -172,7 +172,7 @@ public class MiniMessageImpl implements MiniMessage {
     private final TransformationRegistry registry = new TransformationRegistry();
     private Function<String, ComponentLike> placeholderResolver = DEFAULT_PLACEHOLDER_RESOLVER;
     private boolean strict = false;
-    private Consumer<String> parsingErrorMessageConsumer = DEFAULT_ERROR_CONSUMER;
+    private Consumer<List<String>> parsingErrorMessageConsumer = DEFAULT_ERROR_CONSUMER;
 
     BuilderImpl() {
     }
@@ -227,7 +227,7 @@ public class MiniMessageImpl implements MiniMessage {
     }
 
     @Override
-    public @NonNull Builder parsingErrorMessageConsumer(final Consumer<String> consumer) {
+    public @NonNull Builder parsingErrorMessageConsumer(final Consumer<List<String>> consumer) {
       this.parsingErrorMessageConsumer = consumer;
       return this;
     }

--- a/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistry.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistry.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.text.minimessage.transformation;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -143,17 +144,19 @@ public final class TransformationRegistry {
         throw exception;
       }
       // TODO nicer message format?
-      final Consumer<String> consumer = debugContext.miniMessage().parsingErrorMessageConsumer();
-      consumer.accept("[MiniMessage] Encountered parse exception while trying to load " + transformation.getClass().getSimpleName());
-      consumer.accept("\tmsg=" + exception.getMessage());
-      consumer.accept("\twith name=" + name + " and inners=" + inners + "");
-      consumer.accept("\tinput=" + debugContext.ogMessage());
+      final List<String> errorMessage = new ArrayList<>(Arrays.asList(
+              "[MiniMessage] Encountered parse exception while trying to load " + transformation.getClass().getSimpleName(),
+              "\tmsg=" + exception.getMessage(),
+              "\twith name=" + name + " and inners=" + inners + "",
+              "\tinput=" + debugContext.ogMessage()
+      ));
       if(debugContext.replacedMessage() != null) {
-        consumer.accept("\twith placeholders=" + debugContext.replacedMessage());
+        errorMessage.add("\twith placeholders=" + debugContext.replacedMessage());
       }
       if(inners != null && inners.isEmpty()) {
-        consumer.accept("\thint: did you meant to enter '</" + name + ">'?");
+        errorMessage.add("\thint: did you mean to enter '</" + name + ">'?");
       }
+      debugContext.miniMessage().parsingErrorMessageConsumer().accept(errorMessage);
       return null;
     }
   }


### PR DESCRIPTION
This makes it so each time there is a parse error, the `parsingErrorMessageConsumer` will be called one time, as opposed to one time for each line of text in the error message.

Another approach I considered was changing the consumer to take some type of `TransformationLoadFailureContext` object, which could contain all the context we have when we call the consumer, ie: the `Transformation`, it's name, the passed `Token`s, the `DebugContext`, and the `ParsingException` (and maybe a default formatted error message), but I decided against doing that without discussing it first, because it felt like it might be a bit overkill.