### PR TITLE
JavaDoc: Explain how MiniMessage handles replacing placeholders

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -185,6 +185,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
 
   /**
    * Parses a string into an component, allows passing placeholders using templates (which support components).
+   * MiniMessage parses placeholders from following syntax: {@code <placeholder_name>} where placeholder_name is {@link Template.StringTemplate#key()}
    *
    * @param input the input string
    * @param placeholders the placeholders
@@ -195,6 +196,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
 
   /**
    * Parses a string into an component, allows passing placeholders using templates (which support components).
+   * MiniMessage parses placeholders from following syntax: {@code <placeholder_name>} where placeholder_name is {@link Template.StringTemplate#key()}
    *
    * @param input the input string
    * @param placeholders the placeholders


### PR DESCRIPTION
It was a bit unclear for me how MiniMessage handles replacing. I thought it just replaces literal string. That's why I'd like this information to be in javadocs. It'll help other alot since it's not documented anywhere else. I was thinking about adding the information to Template class, but I think more people would search for info about parsing in MiniMessage#parse().