### PR TITLE
Fix varargs object parser method, improve test

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -108,15 +108,13 @@ public class MiniMessageImpl implements MiniMessage {
       final String key = (String) placeholders[i];
 
       final Object rawValue = placeholders[i + 1];
-      final Component value;
       if(rawValue instanceof String) {
-        value = Component.text((String) rawValue);
+        templates[i / 2] = Template.of(key, (String) rawValue);
       } else if(rawValue instanceof ComponentLike) {
-        value = ((ComponentLike) rawValue).asComponent();
+        templates[i / 2] = Template.of(key, ((ComponentLike) rawValue).asComponent());
       } else {
         throw new IllegalArgumentException("Argument " + (i + 1) + " in placeholders must be Component or String: is value");
       }
-      templates[i / 2] = Template.of(key, value);
     }
 
     return this.parse(input, templates);

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
@@ -87,8 +87,10 @@ public class MiniMessageTest {
     final Component expected = Component.text("")
             .append(Component.text("ONE").color(NamedTextColor.RED))
             .append(Component.text("TWO").color(NamedTextColor.GREEN))
-            .append(Component.text("THREE").color(NamedTextColor.BLUE));
-    final Component result = MiniMessage.get().parse("<red>ONE</red><test><blue>THREE", "test", Component.text("TWO").color(NamedTextColor.GREEN));
+            .append(Component.text("THREEFOUR").color(NamedTextColor.BLUE));
+    final Component result = MiniMessage.get().parse("<red>ONE<component><blue>THREE<string>",
+            "component", Component.text("TWO").color(NamedTextColor.GREEN),
+            "string", "FOUR");
 
     final String out1 = GsonComponentSerializer.gson().serialize(expected);
     final String out2 = GsonComponentSerializer.gson().serialize(result);

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
@@ -87,10 +87,12 @@ public class MiniMessageTest {
     final Component expected = Component.text("")
             .append(Component.text("ONE").color(NamedTextColor.RED))
             .append(Component.text("TWO").color(NamedTextColor.GREEN))
-            .append(Component.text("THREEFOUR").color(NamedTextColor.BLUE));
-    final Component result = MiniMessage.get().parse("<red>ONE<component><blue>THREE<string>",
-            "component", Component.text("TWO").color(NamedTextColor.GREEN),
-            "string", "FOUR");
+            .append(Component.text("THREEFOUR").color(NamedTextColor.BLUE))
+            .append(Component.text("FIVE").color(NamedTextColor.YELLOW));
+    final Component result = MiniMessage.get().parse("<red>ONE<two><blue>THREE<four><five>",
+            "two", Component.text("TWO").color(NamedTextColor.GREEN),
+            "four", "FOUR",
+            "five", Component.text("FIVE").color(NamedTextColor.YELLOW));
 
     final String out1 = GsonComponentSerializer.gson().serialize(expected);
     final String out2 = GsonComponentSerializer.gson().serialize(result);


### PR DESCRIPTION
Fixes MiniMessageImpl#parse(String, Object...) using only ComponentTemplates, since it converted String placeholders to Component placeholders, using Component#text. This leads to the replacements losing formatting e.g. color, decoration if in the middle of another string.