### PR TITLE
Fixed the wrong order of templates translation ( #72 )

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/TemplateTransformation.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/TemplateTransformation.java
@@ -30,7 +30,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.minimessage.Template;
 import net.kyori.adventure.text.minimessage.transformation.Inserting;
-import net.kyori.adventure.text.minimessage.transformation.OneTimeTransformation;
+import net.kyori.adventure.text.minimessage.transformation.InstantApplyTransformation;
 import net.kyori.adventure.text.minimessage.transformation.Transformation;
 import net.kyori.examination.ExaminableProperty;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -40,7 +40,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  *
  * @since 4.1.0
  */
-public final class TemplateTransformation extends OneTimeTransformation implements Inserting {
+public final class TemplateTransformation extends InstantApplyTransformation implements Inserting {
 
   private final Template.ComponentTemplate template;
 
@@ -55,7 +55,7 @@ public final class TemplateTransformation extends OneTimeTransformation implemen
   }
 
   @Override
-  public Component applyOneTime(final @NonNull Component current, final TextComponent.@NonNull Builder parent, final @NonNull Deque<Transformation> transformations) {
+  public void applyInstant(final TextComponent.@NonNull Builder parent, final @NonNull Deque<Transformation> transformations) {
     Component comp = this.template.value();
     // first apply transformations
     for(final Transformation transformation : transformations) {
@@ -65,7 +65,6 @@ public final class TemplateTransformation extends OneTimeTransformation implemen
     comp = this.merge(this.template.value(), comp);
 
     parent.append(comp);
-    return current;
   }
 
   @Override

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -1109,6 +1109,35 @@ public class MiniMessageParserTest {
     assertParsedEquals(expected3, input3);
   }
 
+  @Test
+  void testTemplateOrder() {
+    final Component expected = text()
+            .append(text("ONE", NamedTextColor.GRAY))
+            .append(text("TWO", NamedTextColor.RED))
+            .append(text(" ", NamedTextColor.RED))
+            .append(text("THREE", NamedTextColor.RED))
+            .append(text(" ", NamedTextColor.RED))
+            .append(text("FOUR", NamedTextColor.RED)).build();
+    final String input = "<gray><arg1><red><arg2> <arg3> <arg4>";
+
+    assertParsedEquals(expected, input, "arg1", Component.text("ONE"), "arg2", Component.text("TWO"), "arg3", Component.text("THREE"), "arg4",
+            Component.text("FOUR"));
+  }
+
+  @Test
+  void testTemplateOrder2() {
+    final Component expected = text()
+            .append(text("ONE", NamedTextColor.GRAY))
+            .append(text("TWO", NamedTextColor.RED))
+            .append(text("THREE", NamedTextColor.BLUE))
+            .append(text(" "))
+            .append(text("FOUR", NamedTextColor.GREEN)).build();
+    final String input = "<gray><arg1></gray><red><arg2></red><blue><arg3></blue> <green><arg4>";
+
+    assertParsedEquals(expected, input, "arg1", Component.text("ONE"), "arg2", Component.text("TWO"), "arg3", Component.text("THREE"), "arg4",
+            Component.text("FOUR"));
+  }
+
   private static void assertParsedEquals(final @NonNull Component expected, final @NonNull String input) {
     assertEquals(expected, PARSER.parse(input));
   }


### PR DESCRIPTION
**Issue: #72** 

**Example:**
```java
final Component expected = text()
            .append(text("ONE", NamedTextColor.GRAY))
            .append(text("TWO", NamedTextColor.RED))
            .append(text(" ", NamedTextColor.RED))
            .append(text("THREE", NamedTextColor.RED))
            .append(text(" ", NamedTextColor.RED))
            .append(text("FOUR", NamedTextColor.RED)).build();
    final String input = "<gray><arg1><red><arg2> <arg3> <arg4>";

    final Component actual = PARSER.parse(input, "arg1", Component.text("ONE"), "arg2", Component.text("TWO"), "arg3", Component.text("THREE"), "arg4",
            Component.text("FOUR"));

    // Debug
    LegacyComponentSerializer serializer = LegacyComponentSerializer.legacy('&');

    System.out.println("Expected: " + serializer.serialize(expected));
    System.out.println("Actual: " + serializer.serialize(actual));
```
**Output (without fix):**
```
Expected: &7ONE&cTWO THREE FOUR
Actual: &cTWOONE THREE FOUR
```
This happens because there is no separator between templates. Because of this, templates are applied in reverse order. This also breaks the order in which the styles are applied, because the transformers are in different collections (transformations, oneTimeTransformations).
To fix, templates should be applied instantsly

