### PR TITLE
Fix gradient/rainbow transformations continuing after colored inner text

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/GradientTransformation.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/GradientTransformation.java
@@ -146,7 +146,7 @@ public final class GradientTransformation extends Transformation implements Modi
 
   @Override
   public Component apply(final Component current, final int depth) {
-    if ((this.disableApplyingColorDepth != -1 && depth >= this.disableApplyingColorDepth) || current.style().color() != null) {
+    if ((this.disableApplyingColorDepth != -1 && depth > this.disableApplyingColorDepth) || current.style().color() != null) {
       if (this.disableApplyingColorDepth == -1) {
         this.disableApplyingColorDepth = depth;
       }

--- a/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/RainbowTransformation.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/RainbowTransformation.java
@@ -107,7 +107,7 @@ public final class RainbowTransformation extends Transformation implements Modif
 
   @Override
   public Component apply(final Component current, final int depth) {
-    if ((this.disableApplyingColorDepth != -1 && depth >= this.disableApplyingColorDepth) || current.style().color() != null) {
+    if ((this.disableApplyingColorDepth != -1 && depth > this.disableApplyingColorDepth) || current.style().color() != null) {
       if (this.disableApplyingColorDepth == -1) {
         this.disableApplyingColorDepth = depth;
       }

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -1209,6 +1209,40 @@ public class MiniMessageParserTest extends TestBase {
   }
 
   @Test
+  void testRainbowOrGradientContinuesAfterColoredInner() {
+    final Component expectedRainbow = text()
+      .append(text('r', color(0xf3801f)))
+      .append(text('a', color(0xc9bf03)))
+      .append(text('i', color(0x8bed08)))
+      .append(text('n', color(0x4bff2c)))
+      .append(text("white", WHITE))
+      .append(text()
+        .append(text('b', color(0xb401d3)))
+        .append(text('o', color(0xe71297)))
+        .append(text('w', color(0xfe4056))))
+      .build();
+    final String rainbowInput = "<rainbow>rain<white>white</white>bow";
+
+    this.assertParsedEquals(expectedRainbow, rainbowInput);
+
+    final Component expectedGradient = text()
+      .append(text('g', WHITE))
+      .append(text('r', color(0xebebeb)))
+      .append(text('a', color(0xd8d8d8)))
+      .append(text('d', color(0xc4c4c4)))
+      .append(text("green", GREEN))
+      .append(text()
+        .append(text('i', color(0x4e4e4e)))
+        .append(text('e', color(0x3b3b3b)))
+        .append(text('n', color(0x272727)))
+        .append(text('t', color(0x141414))))
+      .build();
+    final String gradientInput = "<gradient>grad<green>green</green>ient";
+
+    this.assertParsedEquals(expectedGradient, gradientInput);
+  }
+
+  @Test
   void testEscape() {
     final String input = "\\a";
     final Component expected = text("a");


### PR DESCRIPTION
an example this fixes: `<rainbow>rainbow<white>white</white>rainbow`

before this change:
![image](https://user-images.githubusercontent.com/11360596/126028029-4b978760-5681-4571-b598-64d091d3bc5d.png)
after this change:
![image](https://user-images.githubusercontent.com/11360596/126028030-943f8040-1512-4cdd-ac12-4e8414a696d0.png)
