### PR TITLE
Only escape when needed, fixes #134

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TagPart.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TagPart.java
@@ -113,7 +113,7 @@ public final class TagPart {
       endIndex--;
     }
 
-    return TokenParser.unescape(text, startIndex, endIndex);
+    return TokenParser.unescape(text, startIndex, endIndex, i -> i == firstChar);
   }
 
   @Override

--- a/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TextNode.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TextNode.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.text.minimessage.parser.node;
 
+import java.util.function.IntPredicate;
 import net.kyori.adventure.text.minimessage.parser.Token;
 import net.kyori.adventure.text.minimessage.parser.TokenParser;
 import org.jetbrains.annotations.NotNull;
@@ -34,6 +35,8 @@ import org.jetbrains.annotations.Nullable;
  * @since 4.2.0
  */
 public final class TextNode extends ValueNode {
+  private static final IntPredicate ESCAPES = i -> i == '<';
+
   /**
    * Creates a new text node.
    *
@@ -47,7 +50,7 @@ public final class TextNode extends ValueNode {
     final @NotNull Token token,
     final @NotNull String sourceMessage
   ) {
-    super(parent, token, sourceMessage, TokenParser.unescape(sourceMessage, token.startIndex(), token.endIndex()));
+    super(parent, token, sourceMessage, TokenParser.unescape(sourceMessage, token.startIndex(), token.endIndex(), ESCAPES));
   }
 
   @Override

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -411,7 +411,7 @@ public class MiniMessageParserTest extends TestBase {
 
   @Test
   void testBackSpace() {
-    final String input = "\\\\!/ IMPORTANT \\\\!/";
+    final String input = "\\!/ IMPORTANT \\!/";
     final Component expected = text("\\!/ IMPORTANT \\!/");
 
     this.assertParsedEquals(expected, input);
@@ -419,7 +419,7 @@ public class MiniMessageParserTest extends TestBase {
 
   @Test
   void testGH5() {
-    final String input = "<dark_gray>»<gray> To download it from the internet, <click:open_url:'<pack_url>'><hover:show_text:\"<green>/!\\\\\\\\ install it from Options/ResourcePacks in your game\"><green><bold>CLICK HERE</bold></hover></click>";
+    final String input = "<dark_gray>»<gray> To download it from the internet, <click:open_url:'<pack_url>'><hover:show_text:\"<green>/!\\ install it from Options/ResourcePacks in your game\"><green><bold>CLICK HERE</bold></hover></click>";
     final Component expected = empty().color(DARK_GRAY)
       .append(text("»"))
       .append(empty().color(GRAY)
@@ -432,7 +432,7 @@ public class MiniMessageParserTest extends TestBase {
 
   @Test
   void testGH5Modified() {
-    final String input = "<dark_gray>»<gray> To download it from the internet, <click:open_url:'<pack_url>'><hover:show_text:'<green>/!\\\\\\\\ install it from \\'Options/ResourcePacks\\' in your game'><green><bold>CLICK HERE</bold></hover></click>";
+    final String input = "<dark_gray>»<gray> To download it from the internet, <click:open_url:'<pack_url>'><hover:show_text:'<green>/!\\ install it from \\'Options/ResourcePacks\\' in your game'><green><bold>CLICK HERE</bold></hover></click>";
     final Component expected = empty().color(DARK_GRAY)
       .append(text("»"))
       .append(empty().color(GRAY)
@@ -446,7 +446,7 @@ public class MiniMessageParserTest extends TestBase {
 
   @Test
   void testGH5Quoted() {
-    final String input = "<dark_gray>»<gray> To download it from the internet, <click:open_url:\"https://www.google.com\"><hover:show_text:\"<green>/!\\\\\\\\ install it from Options/ResourcePacks in your game\"><green><bold>CLICK HERE</bold></hover></click>";
+    final String input = "<dark_gray>»<gray> To download it from the internet, <click:open_url:\"https://www.google.com\"><hover:show_text:\"<green>/!\\ install it from Options/ResourcePacks in your game\"><green><bold>CLICK HERE</bold></hover></click>";
     final Component expected = empty().color(DARK_GRAY)
       .append(text("»"))
       .append(empty().color(GRAY)
@@ -1242,18 +1242,22 @@ public class MiniMessageParserTest extends TestBase {
     this.assertParsedEquals(expectedGradient, gradientInput);
   }
 
+  // GH-134
   @Test
-  void testEscape() {
-    final String input = "\\a";
-    final Component expected = text("a");
+  void testEscapeOutsideOfContext() {
+    final String input = "\\\"";
+    final Component expected = text("\\\"");
 
     this.assertParsedEquals(expected, input);
   }
 
   @Test
-  void testBareEscape() {
-    final String input = "\\";
-    final Component expected = empty();
+  void testEscapeInsideOfContext() {
+    final String input = "<hover:show_text:'Look at this \\''>Test";
+    final Component expected = text()
+            .content("Test")
+            .hoverEvent(text("Look at this '"))
+            .build();
 
     this.assertParsedEquals(expected, input);
   }


### PR DESCRIPTION
This PR fixes #134 by only escaping when actually needed.

Additionally, some changes that were made to tests were rolled back to what they were before the new parser changes.