### PR TITLE
Implement `TransformationResolver` system

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/Context.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/Context.java
@@ -25,8 +25,8 @@ package net.kyori.adventure.text.minimessage;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.parser.node.ElementNode;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Carries needed context for minimessage around, ranging from debug info to the configured minimessage instance.
@@ -40,16 +40,16 @@ public class Context {
   private final String ogMessage;
   private String replacedMessage;
   private final MiniMessageImpl miniMessage;
-  private final @NotNull Template @Nullable [] templates;
+  private final TemplateResolver templateResolver;
 
-  Context(final boolean strict, final Appendable debugOutput, final ElementNode root, final String ogMessage, final String replacedMessage, final MiniMessageImpl miniMessage, final @NotNull Template @Nullable [] templates) {
+  Context(final boolean strict, final Appendable debugOutput, final ElementNode root, final String ogMessage, final String replacedMessage, final MiniMessageImpl miniMessage, final @NotNull TemplateResolver templateResolver) {
     this.strict = strict;
     this.debugOutput = debugOutput;
     this.root = root;
     this.ogMessage = ogMessage;
     this.replacedMessage = replacedMessage;
     this.miniMessage = miniMessage;
-    this.templates = templates;
+    this.templateResolver = templateResolver;
   }
 
   /**
@@ -62,7 +62,7 @@ public class Context {
    * @since 4.1.0
    */
   public static Context of(final boolean strict, final String input, final MiniMessageImpl miniMessage) {
-    return new Context(strict, null, null, input, null, miniMessage, null);
+    return new Context(strict, null, null, input, null, miniMessage, TemplateResolver.empty());
   }
 
   /**
@@ -76,7 +76,7 @@ public class Context {
    * @since 4.1.0
    */
   public static Context of(final boolean strict, final Appendable debugOutput, final String input, final MiniMessageImpl miniMessage) {
-    return new Context(strict, debugOutput, null, input, null, miniMessage, null);
+    return new Context(strict, debugOutput, null, input, null, miniMessage, TemplateResolver.empty());
   }
 
   /**
@@ -85,12 +85,12 @@ public class Context {
    * @param strict if strict mode is enabled
    * @param input the input message
    * @param miniMessage the minimessage instance
-   * @param templates the templates passed to minimessage
+   * @param templateResolver the templates passed to minimessage
    * @return the debug context
    * @since 4.1.0
    */
-  public static Context of(final boolean strict, final String input, final MiniMessageImpl miniMessage, @NotNull final Template @Nullable [] templates) {
-    return new Context(strict, null, null, input, null, miniMessage, templates);
+  public static Context of(final boolean strict, final String input, final MiniMessageImpl miniMessage, @NotNull final TemplateResolver templateResolver) {
+    return new Context(strict, null, null, input, null, miniMessage, templateResolver);
   }
 
   /**
@@ -100,12 +100,12 @@ public class Context {
    * @param debugOutput where to print debug output
    * @param input the input message
    * @param miniMessage the minimessage instance
-   * @param templates the templates passed to minimessage
+   * @param templateResolver the templates passed to minimessage
    * @return the debug context
    * @since 4.2.0
    */
-  public static Context of(final boolean strict, final Appendable debugOutput, final String input, final MiniMessageImpl miniMessage, @NotNull final Template @Nullable [] templates) {
-    return new Context(strict, debugOutput, null, input, null, miniMessage, templates);
+  public static Context of(final boolean strict, final Appendable debugOutput, final String input, final MiniMessageImpl miniMessage, @NotNull final TemplateResolver templateResolver) {
+    return new Context(strict, debugOutput, null, input, null, miniMessage, templateResolver);
   }
 
   /**
@@ -189,6 +189,16 @@ public class Context {
   }
 
   /**
+   * Returns template resolver.
+   *
+   * @return templateResolver
+   * @since 4.2.0
+   */
+  public TemplateResolver templateResolver() {
+    return this.templateResolver;
+  }
+
+  /**
    * Parses a MiniMessage using all the settings of this context, including templates.
    *
    * @param message the message to parse
@@ -196,10 +206,6 @@ public class Context {
    * @since 4.1.0
    */
   public Component parse(final String message) {
-    if (this.templates != null) {
-      return this.miniMessage.parse(message, this.templates);
-    } else {
-      return this.miniMessage.parse(message);
-    }
+    return this.miniMessage.parser.parseFormat(message, this);
   }
 }

--- a/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/MiniMessage.java
@@ -30,9 +30,11 @@ import java.util.function.Function;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.minimessage.markdown.MarkdownFlavor;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.text.minimessage.transformation.TransformationRegistry;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.util.Buildable;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -76,7 +78,7 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @since 4.0.0
    */
   static @NotNull MiniMessage withMarkdownFlavor(final MarkdownFlavor markdownFlavor) {
-    return new MiniMessageImpl(true, markdownFlavor, TransformationRegistry.builder().build(), MiniMessageImpl.DEFAULT_PLACEHOLDER_RESOLVER, false, null, MiniMessageImpl.DEFAULT_ERROR_CONSUMER);
+    return new MiniMessageImpl(true, markdownFlavor, TransformationRegistry.builder().build(), TemplateResolver.empty(), false, null, MiniMessageImpl.DEFAULT_ERROR_CONSUMER);
   }
 
   /**
@@ -119,8 +121,13 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @param placeholders the placeholders
    * @return the output component
    * @since 4.1.0
+   * @deprecated For removal since 4.2.0, use {@link #parse(String, TemplateResolver)} with {@link TemplateResolver#resolving(Object...)}
    */
-  @NotNull Component parse(final @NotNull String input, final @NotNull String... placeholders);
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
+  default @NotNull Component parse(final @NotNull String input, final @NotNull String... placeholders) {
+    return this.parse(input, TemplateResolver.resolving((Object[]) placeholders));
+  }
 
   /**
    * Parses a string into an component, allows passing placeholders in key value pairs.
@@ -129,8 +136,13 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @param placeholders the placeholders
    * @return the output component
    * @since 4.1.0
+   * @deprecated For removal since 4.2.0, use {@link #parse(String, TemplateResolver)} with {@link TemplateResolver#pairs(Map)}
    */
-  @NotNull Component parse(final @NotNull String input, final @NotNull Map<String, String> placeholders);
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
+  default @NotNull Component parse(final @NotNull String input, final @NotNull Map<String, String> placeholders) {
+    return this.parse(input, TemplateResolver.pairs(placeholders));
+  }
 
   /**
    * Parses a string into an component, allows passing placeholders using key component pairs.
@@ -139,8 +151,13 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @param placeholders the placeholders
    * @return the output component
    * @since 4.1.0
+   * @deprecated For removal since 4.2.0, use {@link #parse(String, TemplateResolver)} with {@link TemplateResolver#resolving(Object...)}
    */
-  @NotNull Component parse(@NotNull String input, @NotNull Object... placeholders);
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
+  default @NotNull Component parse(@NotNull String input, @NotNull Object... placeholders) {
+    return this.parse(input, TemplateResolver.resolving(placeholders));
+  }
 
   /**
    * Parses a string into an component, allows passing placeholders using templates (which support components).
@@ -150,8 +167,13 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @param placeholders the placeholders
    * @return the output component
    * @since 4.0.0
+   * @deprecated For removal since 4.2.0, use {@link #parse(String, TemplateResolver)} with {@link TemplateResolver#templates(Template...)}
    */
-  @NotNull Component parse(final @NotNull String input, final @NotNull Template... placeholders);
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
+  default @NotNull Component parse(final @NotNull String input, final @NotNull Template... placeholders) {
+    return this.parse(input, TemplateResolver.templates(placeholders));
+  }
 
   /**
    * Parses a string into an component, allows passing placeholders using templates (which support components).
@@ -161,8 +183,26 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
    * @param placeholders the placeholders
    * @return the output component
    * @since 4.0.0
+   * @deprecated For removal since 4.2.0, use {@link #parse(String, TemplateResolver)} with {@link TemplateResolver#templates(Iterable)}
    */
-  @NotNull Component parse(final @NotNull String input, final @NotNull List<Template> placeholders);
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
+  default @NotNull Component parse(final @NotNull String input, final @NotNull List<Template> placeholders) {
+    return this.parse(input, TemplateResolver.templates(placeholders));
+  }
+
+  /**
+   * Parses a string into a component, allows passing placeholders using a template resolver (which support components).
+   * MiniMessage parses placeholders from following syntax: {@code <placeholder_name>} where placeholder_name is {@link Template#key()}.
+   *
+   * <p>Any templates provided by this resolver will have priority over templates provided by a resolver in the builder.</p>
+   *
+   * @param input the input string
+   * @param templateResolver the template resolver
+   * @return the output component
+   * @since 4.2.0
+   */
+  @NotNull Component parse(final @NotNull String input, final @NotNull TemplateResolver templateResolver);
 
   /**
    * Creates a new {@link MiniMessage.Builder}.
@@ -215,8 +255,23 @@ public interface MiniMessage extends ComponentSerializer<Component, Component, S
      * @param placeholderResolver the markdown flavor to use
      * @return this builder
      * @since 4.1.0
+     * @deprecated For removal since 4.2.0, use {@link #templateResolver(TemplateResolver)} with {@link TemplateResolver#dynamic(Function)}
      */
-    @NotNull Builder placeholderResolver(final Function<String, ComponentLike> placeholderResolver);
+    @Deprecated
+    default @NotNull Builder placeholderResolver(final Function<String, ComponentLike> placeholderResolver) {
+      return this.templateResolver(placeholderResolver == null ? null : TemplateResolver.dynamic(placeholderResolver));
+    }
+
+    /**
+     * Sets the template resolver.
+     *
+     * <p>Any template resolver provided as a parameter to the parse method will take priority over templates resolved by this resolver.</p>
+     *
+     * @param templateResolver the template resolver
+     * @return this builder
+     * @since 4.2.0
+     */
+    @NotNull Builder templateResolver(final TemplateResolver templateResolver);
 
     /**
      * Allows to enable strict mode (disabled by default)

--- a/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageImpl.java
@@ -23,15 +23,12 @@
  */
 package net.kyori.adventure.text.minimessage;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.minimessage.markdown.MarkdownFlavor;
 import net.kyori.adventure.text.minimessage.markdown.MiniMarkdownParser;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.text.minimessage.transformation.TransformationRegistry;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,23 +38,22 @@ import org.jetbrains.annotations.NotNull;
  * @since 4.0.0
  */
 public class MiniMessageImpl implements MiniMessage {
-  static final Function<String, ComponentLike> DEFAULT_PLACEHOLDER_RESOLVER = s -> null;
   static final Consumer<List<String>> DEFAULT_ERROR_CONSUMER = message -> message.forEach(System.out::println);
 
-  static final MiniMessage INSTANCE = new MiniMessageImpl(false, MarkdownFlavor.defaultFlavor(), TransformationRegistry.standard(), DEFAULT_PLACEHOLDER_RESOLVER, false, null, DEFAULT_ERROR_CONSUMER);
-  static final MiniMessage MARKDOWN = new MiniMessageImpl(true, MarkdownFlavor.defaultFlavor(), TransformationRegistry.standard(), DEFAULT_PLACEHOLDER_RESOLVER, false, null, DEFAULT_ERROR_CONSUMER);
+  static final MiniMessage INSTANCE = new MiniMessageImpl(false, MarkdownFlavor.defaultFlavor(), TransformationRegistry.standard(), TemplateResolver.empty(), false, null, DEFAULT_ERROR_CONSUMER);
+  static final MiniMessage MARKDOWN = new MiniMessageImpl(true, MarkdownFlavor.defaultFlavor(), TransformationRegistry.standard(), TemplateResolver.empty(), false, null, DEFAULT_ERROR_CONSUMER);
 
   private final boolean markdown;
   private final MarkdownFlavor markdownFlavor;
-  private final MiniMessageParser parser;
   private final boolean strict;
   private final Appendable debugOutput;
   private final Consumer<List<String>> parsingErrorMessageConsumer;
+  final MiniMessageParser parser;
 
-  MiniMessageImpl(final boolean markdown, final @NotNull MarkdownFlavor markdownFlavor, final @NotNull TransformationRegistry registry, final @NotNull Function<String, ComponentLike> placeholderResolver, final boolean strict, final Appendable debugOutput, final @NotNull Consumer<List<String>> parsingErrorMessageConsumer) {
+  MiniMessageImpl(final boolean markdown, final @NotNull MarkdownFlavor markdownFlavor, final @NotNull TransformationRegistry registry, final @NotNull TemplateResolver templateResolver, final boolean strict, final Appendable debugOutput, final @NotNull Consumer<List<String>> parsingErrorMessageConsumer) {
     this.markdown = markdown;
     this.markdownFlavor = markdownFlavor;
-    this.parser = new MiniMessageParser(registry, placeholderResolver);
+    this.parser = new MiniMessageParser(registry, templateResolver);
     this.strict = strict;
     this.debugOutput = debugOutput;
     this.parsingErrorMessageConsumer = parsingErrorMessageConsumer;
@@ -77,73 +73,12 @@ public class MiniMessageImpl implements MiniMessage {
   }
 
   @Override
-  public @NotNull Component parse(@NotNull String input, final @NotNull String... placeholders) {
+  public @NotNull Component parse(@NotNull String input, final @NotNull TemplateResolver templateResolver) {
     if (this.markdown) {
       input = MiniMarkdownParser.parse(input, this.markdownFlavor);
     }
-    return this.parser.parseFormat(input, Context.of(this.strict, this.debugOutput, input, this), placeholders);
-  }
 
-  @Override
-  public @NotNull Component parse(@NotNull String input, final @NotNull Map<String, String> placeholders) {
-    if (this.markdown) {
-      input = MiniMarkdownParser.parse(input, this.markdownFlavor);
-    }
-    return this.parser.parseFormat(input, placeholders, Context.of(this.strict, this.debugOutput, input, this));
-  }
-
-  @Override
-  public @NotNull Component parse(final @NotNull String input, final @NotNull Object... placeholders) {
-    final List<Template> templates = new ArrayList<>();
-    String key = null;
-    for (int i = 0; i < placeholders.length; i++) {
-      final Object object = placeholders[i];
-      if (object instanceof Template) {
-        // add as a template directly
-        templates.add((Template) object);
-      } else {
-        // this is a `key=[string|component]` template
-        if (key == null) {
-          // get the key
-          if (object instanceof String) {
-            key = (String) object;
-          } else {
-            throw new IllegalArgumentException("Argument " + i + " in placeholders is key, must be String, was " + object.getClass().getName());
-          }
-        } else {
-          // get the value
-          if (object instanceof ComponentLike) {
-            templates.add(Template.of(key, ((ComponentLike) object).asComponent()));
-            key = null;
-          } else if (object instanceof String) {
-            templates.add(Template.of(key, (String) object));
-            key = null;
-          } else {
-            throw new IllegalArgumentException("Argument " + i + " in placeholders is a value, must be Component or String, was " + object.getClass().getName());
-          }
-        }
-      }
-    }
-    if (key != null) {
-      throw new IllegalArgumentException("Found a key in placeholders that wasn't followed by a value: " + key);
-    }
-    return this.parse(input, templates);
-  }
-
-  @Override
-  public @NotNull Component parse(@NotNull String input, final @NotNull Template... placeholders) {
-    if (this.markdown) {
-      input = MiniMarkdownParser.parse(input, this.markdownFlavor);
-    }
-    return this.parser.parseFormat(input, Context.of(this.strict, this.debugOutput, input, this, placeholders), placeholders);
-  }
-
-  @Override
-  public @NotNull Component parse(@NotNull String input, final @NotNull List<Template> placeholders) {
-    if (this.markdown) {
-      input = MiniMarkdownParser.parse(input, this.markdownFlavor);
-    }
-    return this.parser.parseFormat(input, placeholders, Context.of(this.strict, this.debugOutput, input, this, placeholders.toArray(new Template[0])));
+    return this.parser.parseFormat(input, Context.of(this.strict, this.debugOutput, input, this, templateResolver));
   }
 
   @Override
@@ -178,7 +113,7 @@ public class MiniMessageImpl implements MiniMessage {
     private boolean markdown = false;
     private MarkdownFlavor markdownFlavor = MarkdownFlavor.defaultFlavor();
     private TransformationRegistry registry = TransformationRegistry.standard();
-    private Function<String, ComponentLike> placeholderResolver = DEFAULT_PLACEHOLDER_RESOLVER;
+    private TemplateResolver templateResolver = null;
     private boolean strict = false;
     private Appendable debug = null;
     private Consumer<List<String>> parsingErrorMessageConsumer = DEFAULT_ERROR_CONSUMER;
@@ -209,8 +144,8 @@ public class MiniMessageImpl implements MiniMessage {
     }
 
     @Override
-    public @NotNull Builder placeholderResolver(final Function<String, ComponentLike> placeholderResolver) {
-      this.placeholderResolver = placeholderResolver;
+    public @NotNull Builder templateResolver(final TemplateResolver templateResolver) {
+      this.templateResolver = templateResolver;
       return this;
     }
 
@@ -235,9 +170,9 @@ public class MiniMessageImpl implements MiniMessage {
     @Override
     public @NotNull MiniMessage build() {
       if (this.markdown) {
-        return new MiniMessageImpl(true, this.markdownFlavor, this.registry, this.placeholderResolver, this.strict, this.debug, this.parsingErrorMessageConsumer);
+        return new MiniMessageImpl(true, this.markdownFlavor, this.registry, this.templateResolver == null ? TemplateResolver.empty() : this.templateResolver, this.strict, this.debug, this.parsingErrorMessageConsumer);
       } else {
-        return new MiniMessageImpl(false, MarkdownFlavor.defaultFlavor(), this.registry, this.placeholderResolver, this.strict, this.debug, this.parsingErrorMessageConsumer);
+        return new MiniMessageImpl(false, MarkdownFlavor.defaultFlavor(), this.registry, this.templateResolver == null ? TemplateResolver.empty() : this.templateResolver, this.strict, this.debug, this.parsingErrorMessageConsumer);
       }
     }
   }

--- a/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -25,17 +25,13 @@ package net.kyori.adventure.text.minimessage;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.minimessage.parser.ParsingException;
@@ -44,6 +40,7 @@ import net.kyori.adventure.text.minimessage.parser.TokenParser;
 import net.kyori.adventure.text.minimessage.parser.node.ElementNode;
 import net.kyori.adventure.text.minimessage.parser.node.TagNode;
 import net.kyori.adventure.text.minimessage.parser.node.ValueNode;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.text.minimessage.transformation.Modifying;
 import net.kyori.adventure.text.minimessage.transformation.Transformation;
 import net.kyori.adventure.text.minimessage.transformation.TransformationRegistry;
@@ -59,16 +56,16 @@ final class MiniMessageParser {
   private static final Pattern pattern = Pattern.compile("((?<start><)(?<token>[^<>]+(:(?<inner>['\"]?([^'\"](\\\\['\"])?)+['\"]?))*)(?<end>>))+?");
 
   private final TransformationRegistry registry;
-  private final Function<String, ComponentLike> placeholderResolver;
+  private final TemplateResolver templateResolver;
 
   MiniMessageParser() {
     this.registry = TransformationRegistry.standard();
-    this.placeholderResolver = MiniMessageImpl.DEFAULT_PLACEHOLDER_RESOLVER;
+    this.templateResolver = TemplateResolver.empty();
   }
 
-  MiniMessageParser(final TransformationRegistry registry, final Function<String, ComponentLike> placeholderResolver) {
+  MiniMessageParser(final TransformationRegistry registry, final TemplateResolver templateResolver) {
     this.registry = registry;
-    this.placeholderResolver = placeholderResolver;
+    this.templateResolver = templateResolver;
   }
 
   @NotNull String escapeTokens(final @NotNull String richMessage) {
@@ -125,54 +122,9 @@ final class MiniMessageParser {
     return sb.toString();
   }
 
-  @NotNull Component parseFormat(final @NotNull String richMessage, final @NotNull Context context, final @NotNull String... placeholders) {
-    if (placeholders.length % 2 != 0) {
-      throw new ParsingException(
-        "Invalid number placeholders defined, usage: parseFormat(format, key, value, key, value...)");
-    }
-
-    final Template[] t = new Template[placeholders.length / 2];
-    for (int i = 0; i < placeholders.length; i += 2) {
-      t[i / 2] = Template.of(placeholders[i], placeholders[i + 1]);
-    }
-
-    return this.parseFormat(richMessage, context, t);
-  }
-
-  @NotNull Component parseFormat(final @NotNull String richMessage, final @NotNull Map<String, String> placeholders, final Context context) {
-    final Template[] t = new Template[placeholders.size()];
-    int i = 0;
-    for (final Map.Entry<String, String> entry : placeholders.entrySet()) {
-      t[i++] = Template.of(entry.getKey(), entry.getValue());
-    }
-    return this.parseFormat(richMessage, context, t);
-  }
-
-  @NotNull Component parseFormat(final @NotNull String input, final Context context, final @NotNull Template... placeholders) {
-    final Map<String, Template> map = new HashMap<>();
-    for (final Template placeholder : placeholders) {
-      map.put(placeholder.key(), placeholder);
-    }
-    return this.parseFormat0(input, map, context);
-  }
-
-  @NotNull Component parseFormat(final @NotNull String input, final @NotNull List<Template> placeholders, final @NotNull Context context) {
-    final Map<String, Template> map = new HashMap<>();
-    for (final Template placeholder : placeholders) {
-      map.put(placeholder.key(), placeholder);
-    }
-    return this.parseFormat0(input, map, context);
-  }
-
   @NotNull Component parseFormat(final @NotNull String richMessage, final @NotNull Context context) {
-    return this.parseFormat0(richMessage, Collections.emptyMap(), context);
-  }
+    final TemplateResolver combinedResolver = TemplateResolver.combining(context.templateResolver(), this.templateResolver);
 
-  @NotNull Component parseFormat0(final @NotNull String richMessage, final @NotNull Map<String, Template> templates, final @NotNull Context context) {
-    return this.parseFormat0(richMessage, templates, this.registry, this.placeholderResolver, context);
-  }
-
-  @NotNull Component parseFormat0(final @NotNull String richMessage, final @NotNull Map<String, Template> templates, final @NotNull TransformationRegistry registry, final @NotNull Function<String, ComponentLike> placeholderResolver, final Context context) {
     final Appendable debug = context.debugOutput();
     if (debug != null) {
       try {
@@ -187,18 +139,18 @@ final class MiniMessageParser {
         try {
           try {
             debug.append("Attempting to match node '").append(node.name()).append("' at column ")
-              .append(String.valueOf(node.token().startIndex())).append('\n');
+                    .append(String.valueOf(node.token().startIndex())).append('\n');
           } catch (final IOException ignored) {
           }
 
-          final Transformation transformation = registry.get(node.name(), node.parts(), templates, placeholderResolver, context);
+          final Transformation transformation = this.registry.get(node.name(), node.parts(), context.templateResolver(), context);
 
           try {
             if (transformation == null) {
               debug.append("Could not match node '").append(node.name()).append("'\n");
             } else {
               debug.append("Successfully matched node '").append(node.name()).append("' to transformation ")
-                .append(transformation.examinableName()).append('\n');
+                      .append(transformation.examinableName()).append('\n');
             }
           } catch (final IOException ignored) {
           }
@@ -218,16 +170,16 @@ final class MiniMessageParser {
     } else {
       transformationFactory = node -> {
         try {
-          return registry.get(node.name(), node.parts(), templates, placeholderResolver, context);
+          return this.registry.get(node.name(), node.parts(), combinedResolver, context);
         } catch (final ParsingException ignored) {
           return null;
         }
       };
     }
     final BiPredicate<String, Boolean> tagNameChecker = (name, includeTemplates) ->
-      registry.exists(name, placeholderResolver) || (includeTemplates && templates.containsKey(name));
+            this.registry.exists(name, combinedResolver) || (includeTemplates && combinedResolver.canResolve(name));
 
-    final ElementNode root = TokenParser.parse(transformationFactory, tagNameChecker, templates, richMessage, context.strict(), true);
+    final ElementNode root = TokenParser.parse(transformationFactory, tagNameChecker, combinedResolver, richMessage, context.strict(), true);
 
     if (debug != null) {
       try {

--- a/src/main/java/net/kyori/adventure/text/minimessage/Template.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/Template.java
@@ -23,12 +23,15 @@
  */
 package net.kyori.adventure.text.minimessage;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
 import net.kyori.examination.Examinable;
 import net.kyori.examination.ExaminableProperty;
 import net.kyori.examination.string.StringExaminer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -44,9 +47,12 @@ public interface Template extends Examinable {
    * @param value the value to replace the key with
    * @return the constructed template
    * @since 4.0.0
+   * @deprecated For removal since 4.2.0, use {@link #template(String, String)}.
    */
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
   static @NotNull Template of(final @NotNull String key, final @NotNull String value) {
-    return new StringTemplate(key, value);
+    return template(key, value);
   }
 
   /**
@@ -56,9 +62,51 @@ public interface Template extends Examinable {
    * @param value the component to replace the key with
    * @return the constructed template
    * @since 4.0.0
+   * @deprecated For removal since 4.2.0, use {@link #template(String, ComponentLike)}
    */
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
   static @NotNull Template of(final @NotNull String key, final @NotNull Component value) {
-    return new ComponentTemplate(key, value);
+    return template(key, value);
+  }
+
+  /**
+   * Constructs a template that gets replaced with a component lazily.
+   *
+   * @param key the placeholder
+   * @param value the supplier that supplies the component to replace the key with
+   * @return the constructed template
+   * @since 4.2.0
+   * @deprecated For removal since 4.2.0, use {@link #template(String, Supplier)}
+   */
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
+  static @NotNull Template of(final @NotNull String key, final @NotNull Supplier<Component> value) {
+    return template(key, value);
+  }
+
+  /**
+   * Constructs a template that gets replaced with a string.
+   *
+   * @param key the placeholder
+   * @param value the value to replace the key with
+   * @return the constructed template
+   * @since 4.2.0
+   */
+  static @NotNull Template template(final @NotNull String key, final @NotNull String value) {
+    return new StringTemplate(Objects.requireNonNull(key, "key"), Objects.requireNonNull(value, "value"));
+  }
+
+  /**
+   * Constructs a template that gets replaced with a component.
+   *
+   * @param key the placeholder
+   * @param value the component to replace the key with
+   * @return the constructed template
+   * @since 4.2.0
+   */
+  static @NotNull Template template(final @NotNull String key, final @NotNull ComponentLike value) {
+    return new ComponentTemplate(Objects.requireNonNull(key, "key"), Objects.requireNonNull(value, "value").asComponent());
   }
 
   /**
@@ -69,8 +117,8 @@ public interface Template extends Examinable {
    * @return the constructed template
    * @since 4.2.0
    */
-  static @NotNull Template of(final @NotNull String key, final @NotNull Supplier<Component> value) {
-    return new LazyComponentTemplate(key, value);
+  static @NotNull Template template(final @NotNull String key, final @NotNull Supplier<? extends ComponentLike> value) {
+    return new LazyComponentTemplate(Objects.requireNonNull(key, "key"), Objects.requireNonNull(value, "value"));
   }
 
   /**
@@ -171,16 +219,16 @@ public interface Template extends Examinable {
    * @since 4.2.0
    */
   class LazyComponentTemplate extends ComponentTemplate {
-    private final @NotNull Supplier<Component> value;
+    private final @NotNull Supplier<? extends ComponentLike> value;
 
-    public LazyComponentTemplate(final @NotNull String key, final @NotNull Supplier<Component> value) {
+    public LazyComponentTemplate(final @NotNull String key, final @NotNull Supplier<? extends ComponentLike> value) {
       super(key, Component.empty());
       this.value = value;
     }
 
     @Override
     public @NotNull Component value() {
-      return this.value.get();
+      return this.value.get().asComponent();
     }
 
     @Override

--- a/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import net.kyori.adventure.text.minimessage.Template;
@@ -37,6 +36,7 @@ import net.kyori.adventure.text.minimessage.parser.node.TagNode;
 import net.kyori.adventure.text.minimessage.parser.node.TagPart;
 import net.kyori.adventure.text.minimessage.parser.node.TemplateNode;
 import net.kyori.adventure.text.minimessage.parser.node.TextNode;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.text.minimessage.transformation.Inserting;
 import net.kyori.adventure.text.minimessage.transformation.Transformation;
 import org.jetbrains.annotations.NotNull;
@@ -61,7 +61,7 @@ public final class TokenParser {
   public static ElementNode parse(
     final @NotNull Function<TagNode, @Nullable Transformation> transformationFactory,
     final @NotNull BiPredicate<String, Boolean> tagNameChecker,
-    final @NotNull Map<String, Template> templates,
+    final @NotNull TemplateResolver templateResolver,
     final @NotNull String message,
     final boolean strict,
     final boolean recursivelyResolveStringPlaceholders
@@ -69,7 +69,7 @@ public final class TokenParser {
     final List<Token> tokens = parseFirstPass(message);
     parseSecondPass(message, tokens);
 
-    return buildTree(transformationFactory, tagNameChecker, templates, tokens, message, strict, recursivelyResolveStringPlaceholders);
+    return buildTree(transformationFactory, tagNameChecker, templateResolver, tokens, message, strict, recursivelyResolveStringPlaceholders);
   }
 
   /*
@@ -279,7 +279,7 @@ public final class TokenParser {
   private static ElementNode buildTree(
     final @NotNull Function<TagNode, @Nullable Transformation> transformationFactory,
     final @NotNull BiPredicate<String, Boolean> tagNameChecker,
-    final @NotNull Map<String, Template> templates,
+    final @NotNull TemplateResolver templateResolver,
     final @NotNull List<Token> tokens,
     final @NotNull String message,
     final boolean strict,
@@ -296,7 +296,7 @@ public final class TokenParser {
           break;
 
         case OPEN_TAG:
-          final TagNode tagNode = new TagNode(node, token, message, templates);
+          final TagNode tagNode = new TagNode(node, token, message, templateResolver);
           if (tagNode.name().equals("reset")) {
             // <reset> tags get special treatment and don't appear in the tree
             // instead, they close all currently open tags
@@ -311,12 +311,12 @@ public final class TokenParser {
 
             continue;
           } else {
-            final Template template = templates.get(tagNode.name());
+            final Template template = templateResolver.resolve(tagNode.name());
             if (template instanceof Template.StringTemplate) {
               final String value = ((Template.StringTemplate) template).value();
 
               if (recursivelyResolveStringPlaceholders) {
-                node.addChild(TokenParser.parse(transformationFactory, tagNameChecker, templates, value, strict, false));
+                node.addChild(TokenParser.parse(transformationFactory, tagNameChecker, templateResolver, value, strict, false));
               } else {
                 node.addChild(new TemplateNode(node, token, message, value));
               }

--- a/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TagNode.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TagNode.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import net.kyori.adventure.text.minimessage.Template;
 import net.kyori.adventure.text.minimessage.parser.ParsingException;
 import net.kyori.adventure.text.minimessage.parser.Token;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.text.minimessage.transformation.Transformation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -50,27 +51,47 @@ public final class TagNode extends ElementNode {
    * @param token         the token that created this node
    * @param sourceMessage the source message
    * @since 4.2.0
+   * @deprecated For removal since 4.2.0, use {@link #TagNode(ElementNode, Token, String, TemplateResolver)} with {@link TemplateResolver#pairs(Map)}
    */
+  @Deprecated
   public TagNode(
     final @NotNull ElementNode parent,
     final @NotNull Token token,
     final @NotNull String sourceMessage,
     final @NotNull Map<String, Template> templates
   ) {
+    this(parent, token, sourceMessage, TemplateResolver.pairs(templates));
+  }
+
+  /**
+   * Creates a new element node.
+   *
+   * @param parent the parent of this node
+   * @param token the token that created this node
+   * @param sourceMessage the source message
+   * @param templateResolver the template resolver
+   * @since 4.2.0
+   */
+  public TagNode(
+    final @NotNull ElementNode parent,
+    final @NotNull Token token,
+    final @NotNull String sourceMessage,
+    final @NotNull TemplateResolver templateResolver
+  ) {
     super(parent, token, sourceMessage);
-    this.parts = genParts(token, sourceMessage, templates);
+    this.parts = genParts(token, sourceMessage, templateResolver);
   }
 
   private static @NotNull List<TagPart> genParts(
     final @NotNull Token token,
     final @NotNull String sourceMessage,
-    final @NotNull Map<String, Template> templates
+    final @NotNull TemplateResolver templateResolver
   ) {
     final ArrayList<TagPart> parts = new ArrayList<>();
 
     if (token.childTokens() != null) {
       for (final Token childToken : token.childTokens()) {
-        parts.add(new TagPart(sourceMessage, childToken, templates));
+        parts.add(new TagPart(sourceMessage, childToken, templateResolver));
       }
     }
 

--- a/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TagPart.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TagPart.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import net.kyori.adventure.text.minimessage.Template;
 import net.kyori.adventure.text.minimessage.parser.Token;
 import net.kyori.adventure.text.minimessage.parser.TokenParser;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -44,7 +46,10 @@ public final class TagPart {
    * @param sourceMessage the source message
    * @param token the token that creates this tag part
    * @since 4.2.0
+   * @deprecated For removal since 4.2.0, use {@link #TagPart(String, Token, TemplateResolver)} with {@link TemplateResolver#pairs(Map)}
    */
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
   public TagPart(
     final @NotNull String sourceMessage,
     final @NotNull Token token,
@@ -54,6 +59,31 @@ public final class TagPart {
     if (isTag(v)) {
       final String text = v.substring(1, v.length() - 1);
       final Template template = templates.get(text);
+      if (template instanceof Template.StringTemplate) {
+        v = ((Template.StringTemplate) template).value();
+      }
+    }
+
+    this.value = v;
+    this.token = token;
+  }
+
+  /**
+   * Constructs a new tag part.
+   *
+   * @param sourceMessage the source message
+   * @param token the token that creates this tag part
+   * @since 4.2.0
+   */
+  public TagPart(
+    final @NotNull String sourceMessage,
+    final @NotNull Token token,
+    final @NotNull TemplateResolver templateResolver
+  ) {
+    String v = unquoteAndEscape(sourceMessage, token.startIndex(), token.endIndex());
+    if (isTag(v)) {
+      final String text = v.substring(1, v.length() - 1);
+      final Template template = templateResolver.resolve(text);
       if (template instanceof Template.StringTemplate) {
         v = ((Template.StringTemplate) template).value();
       }

--- a/src/main/java/net/kyori/adventure/text/minimessage/template/DynamicTemplateResolver.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/template/DynamicTemplateResolver.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of adventure-text-minimessage, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.template;
+
+import java.util.function.Function;
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.minimessage.Template;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class DynamicTemplateResolver implements TemplateResolver {
+  private final Function<String, ?> resolver;
+
+  DynamicTemplateResolver(final Function<String, ?> resolver) {
+    this.resolver = resolver;
+  }
+
+  @Override
+  public boolean canResolve(final @NotNull String key) {
+    final Object result = this.resolver.apply(key);
+    return result instanceof ComponentLike || result instanceof String;
+  }
+
+  @Override
+  public @Nullable Template resolve(final @NotNull String key) {
+    final Object result = this.resolver.apply(key);
+
+    if (result == null) return null;
+    else if (result instanceof String) return Template.template(key, (String) result);
+    else if (result instanceof ComponentLike) return Template.template(key, (ComponentLike) result);
+    else if (result instanceof Template) return (Template) result;
+
+    throw new IllegalArgumentException("Dynamic template resolver must return instances of String or ComponentLike, instead found " + result.getClass().getName());
+  }
+}

--- a/src/main/java/net/kyori/adventure/text/minimessage/template/EmptyTemplateResolver.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/template/EmptyTemplateResolver.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of adventure-text-minimessage, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.template;
+
+import net.kyori.adventure.text.minimessage.Template;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An empty template resolver that has no templates.
+ */
+final class EmptyTemplateResolver implements TemplateResolver {
+  static final EmptyTemplateResolver INSTANCE = new EmptyTemplateResolver();
+
+  private EmptyTemplateResolver() {
+  }
+
+  @Override
+  public boolean canResolve(final @NotNull String key) {
+    return false;
+  }
+
+  @Override
+  public @Nullable Template resolve(final @NotNull String key) {
+    return null;
+  }
+}

--- a/src/main/java/net/kyori/adventure/text/minimessage/template/FilteringTemplateResolver.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/template/FilteringTemplateResolver.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of adventure-text-minimessage, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.template;
+
+import java.util.function.Predicate;
+import net.kyori.adventure.text.minimessage.Template;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class FilteringTemplateResolver implements TemplateResolver {
+  private final TemplateResolver templateResolver;
+  private final Predicate<Template> filter;
+
+  FilteringTemplateResolver(final TemplateResolver templateResolver, final Predicate<Template> filter) {
+    this.templateResolver = templateResolver;
+    this.filter = filter;
+  }
+
+  @Override
+  public boolean canResolve(final @NotNull String key) {
+    return this.resolve(key) != null;
+  }
+
+  @Override
+  public @Nullable Template resolve(final @NotNull String key) {
+    final Template template = this.templateResolver.resolve(key);
+    if (template == null || this.filter.test(template)) return null;
+    return template;
+  }
+}

--- a/src/main/java/net/kyori/adventure/text/minimessage/template/GroupedTemplateResolver.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/template/GroupedTemplateResolver.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of adventure-text-minimessage, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.template;
+
+import net.kyori.adventure.text.minimessage.Template;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A template resolver that resolves from two sources.
+ */
+final class GroupedTemplateResolver implements TemplateResolver {
+  private final Iterable<? extends TemplateResolver> templateResolvers;
+
+  GroupedTemplateResolver(final @NotNull Iterable<? extends TemplateResolver> templateResolvers) {
+    this.templateResolvers = templateResolvers;
+  }
+
+  @Override
+  public boolean canResolve(final @NotNull String key) {
+    for (final TemplateResolver templateResolver : this.templateResolvers) {
+      if (templateResolver.canResolve(key)) return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public @Nullable Template resolve(final @NotNull String key) {
+    for (final TemplateResolver templateResolver : this.templateResolvers) {
+      final Template template = templateResolver.resolve(key);
+      if (template != null) return template;
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/net/kyori/adventure/text/minimessage/template/MapTemplateResolver.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/template/MapTemplateResolver.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of adventure-text-minimessage, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.template;
+
+import java.util.Map;
+import net.kyori.adventure.text.minimessage.Template;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A template resolver based on a map.
+ */
+final class MapTemplateResolver implements TemplateResolver {
+  private final Map<String, Template> templateMap;
+
+  MapTemplateResolver(final @NotNull Map<String, Template> templateMap) {
+    this.templateMap = templateMap;
+  }
+
+  @Override
+  public boolean canResolve(final @NotNull String key) {
+    return this.templateMap.containsKey(key);
+  }
+
+  @Override
+  public @Nullable Template resolve(final @NotNull String key) {
+    return this.templateMap.get(key);
+  }
+}

--- a/src/main/java/net/kyori/adventure/text/minimessage/template/TemplateResolver.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/template/TemplateResolver.java
@@ -1,0 +1,231 @@
+/*
+ * This file is part of adventure-text-minimessage, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.minimessage.template;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.minimessage.Template;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A resolver for user-defined templates.
+ *
+ * @since 4.2.0
+ */
+public interface TemplateResolver {
+  /**
+   * Constructs a template resolver from key-value pairs or {@link Template} instances.
+   *
+   * <p>The {@code pairs} arguments must be a string key followed by a string or {@link ComponentLike} value or a {@link Template}.</p>
+   *
+   * @param objects the objects
+   * @return the template resolver
+   * @since 4.2.0
+   */
+  static @NotNull TemplateResolver resolving(final @NotNull Object @NotNull ... objects) {
+    final int size = Objects.requireNonNull(objects, "pairs").length;
+
+    if (size == 0) return empty();
+
+    String key = null;
+
+    final Map<String, Template> templateMap = new HashMap<>(size);
+    for (int i = 0; i < size; i++) {
+      final Object obj = objects[i];
+
+      if (key == null) {
+        // we are looking for a key or a template
+        if (obj instanceof Template) {
+          final Template template = (Template) obj;
+          templateMap.put(template.key(), template);
+        } else if (obj instanceof String) {
+          key = (String) obj;
+        } else {
+          throw new IllegalArgumentException("Argument " + i + " in pairs must be a String key or a Template, was " + obj.getClass().getName());
+        }
+      } else {
+        // we are looking for a value
+        if (obj instanceof String) {
+          templateMap.put(key, Template.template(key, (String) obj));
+        } else if (obj instanceof ComponentLike) {
+          templateMap.put(key, Template.template(key, (ComponentLike) obj));
+        } else {
+          throw new IllegalArgumentException("Argument " + i + " in pairs must be a String or ComponentLike value, was " + obj.getClass().getName());
+        }
+
+        key = null;
+      }
+    }
+
+    if (key != null) {
+      throw new IllegalArgumentException("Found key \"" + key + "\" in objects that wasn't followed by a value.");
+    }
+
+    if (templateMap.isEmpty()) return empty();
+
+    return new MapTemplateResolver(templateMap);
+  }
+
+  /**
+   * Constructs a template resolver from key-value pairs.
+   *
+   * <p>The values must be instances of String, {@link ComponentLike} or {@link Template}.</p>
+   *
+   * @param pairs the key-value pairs
+   * @return the template resolver
+   * @since 4.2.0
+   */
+  static @NotNull TemplateResolver pairs(final @NotNull Map<String, ?> pairs) {
+    final int size = Objects.requireNonNull(pairs, "pairs").size();
+
+    if (size == 0) return empty();
+
+    final Map<String, Template> templateMap = new HashMap<>(size);
+
+    for (final Map.Entry<String, ?> entry : pairs.entrySet()) {
+      final String key = entry.getKey();
+      final Object value = entry.getValue();
+
+      if (value instanceof String) templateMap.put(key, Template.template(key, (String) value));
+      else if (value instanceof ComponentLike) templateMap.put(key, Template.template(key, (ComponentLike) value));
+      else if (value instanceof Template) templateMap.put(key, (Template) value);
+      else
+        throw new IllegalArgumentException("Values must be either ComponentLike or String but " + value + " was not.");
+    }
+
+    return new MapTemplateResolver(templateMap);
+  }
+
+  /**
+   * Constructs a template resolver from some templates.
+   *
+   * @param templates the templates
+   * @return the template resolver
+   * @since 4.2.0
+   */
+  static @NotNull TemplateResolver templates(final @NotNull Template @NotNull ... templates) {
+    if (Objects.requireNonNull(templates, "templates").length == 0) return empty();
+    return templates(Arrays.asList(templates));
+  }
+
+  /**
+   * Constructs a template resolver from some templates.
+   *
+   * @param templates the templates
+   * @return the template resolver
+   * @since 4.2.0
+   */
+  static @NotNull TemplateResolver templates(final @NotNull Iterable<? extends Template> templates) {
+    final Map<String, Template> templateMap = new HashMap<>();
+
+    for (final Template template : templates) {
+      templateMap.put(template.key(), template);
+    }
+
+    if (templateMap.isEmpty()) return empty();
+
+    return new MapTemplateResolver(templateMap);
+  }
+
+  /**
+   * Constructs a template resolver capable of resolving from multiple sources.
+   *
+   * @param templateResolvers the template resolvers
+   * @return the template resolver
+   * @since 4.2.0
+   */
+  static @NotNull TemplateResolver combining(final @NotNull TemplateResolver @NotNull ... templateResolvers) {
+    if (templateResolvers.length == 1) return templateResolvers[0];
+    return new GroupedTemplateResolver(Arrays.asList(templateResolvers));
+  }
+
+  /**
+   * Constructs a template resolver capable of resolving from multiple sources.
+   *
+   * @param templateResolvers the template resolvers
+   * @return the template resolver
+   * @since 4.2.0
+   */
+  static @NotNull TemplateResolver combining(final @NotNull Iterable<? extends TemplateResolver> templateResolvers) {
+    return new GroupedTemplateResolver(Objects.requireNonNull(templateResolvers, "templateResolvers"));
+  }
+
+  /**
+   * Constructs a template resolver capable of dynamically resolving templates.
+   * <p>The {@code resolver} function must return instances of String, {@link ComponentLike} or {@link Template}.</p>
+   *
+   * @param resolver the resolver
+   * @return the template resolver
+   * @since 4.2.0
+   */
+  static @NotNull TemplateResolver dynamic(final @NotNull Function<String, ?> resolver) {
+    return new DynamicTemplateResolver(Objects.requireNonNull(resolver, "resolver"));
+  }
+
+  /**
+   * Constructs a template resolver that uses the provided filter to prevent the resolving of templates that match the filter.
+   *
+   * @param templateResolver the template resolver
+   * @param filter           the filter
+   * @return the template resolver
+   * @since 4.2.0
+   */
+  static @NotNull TemplateResolver filtering(final @NotNull TemplateResolver templateResolver, final @NotNull Predicate<Template> filter) {
+    return new FilteringTemplateResolver(Objects.requireNonNull(templateResolver, "templateResolver"), Objects.requireNonNull(filter, "filter"));
+  }
+
+  /**
+   * An empty template resolver that will return {@code null} for all resolve attempts.
+   *
+   * @return the template resolver
+   * @since 4.2.0
+   */
+  static @NotNull TemplateResolver empty() {
+    return EmptyTemplateResolver.INSTANCE;
+  }
+
+  /**
+   * Checks if this template resolver can resolve a template from a key.
+   *
+   * @param key the key
+   * @return if a template can be resolved from this key
+   * @since 4.2.0
+   */
+  boolean canResolve(final @NotNull String key);
+
+  /**
+   * Returns a template from a given key, if any exist.
+   *
+   * @param key the key
+   * @return the template
+   * @since 4.2.0
+   */
+  @Nullable Template resolve(final @NotNull String key);
+}

--- a/src/main/java/net/kyori/adventure/text/minimessage/template/package-info.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/template/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of adventure-text-minimessage, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2021 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Templates.
+ */
+package net.kyori.adventure.text.minimessage.template;

--- a/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistry.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistry.java
@@ -30,7 +30,9 @@ import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.Template;
 import net.kyori.adventure.text.minimessage.parser.node.TagPart;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.util.Buildable;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -52,7 +54,21 @@ public interface TransformationRegistry {
    * @return a possible transformation
    * @since 4.1.0
    */
-  @Nullable Transformation get(final String name, final List<TagPart> inners, final Map<String, Template> templates, final Function<String, ComponentLike> placeholderResolver, final Context context);
+  default @Nullable Transformation get(final String name, final List<TagPart> inners, final Map<String, Template> templates, final Function<String, ComponentLike> placeholderResolver, final Context context) {
+    return this.get(name, inners, TemplateResolver.combining(TemplateResolver.pairs(templates), TemplateResolver.dynamic(placeholderResolver)), context);
+  }
+
+  /**
+   * Get a transformation from this registry based on the current state.
+   *
+   * @param name tag name
+   * @param inners tokens that make up the tag arguments
+   * @param templateResolver the template resolver
+   * @param context the debug context
+   * @return a possible transformation
+   * @since 4.1.0
+   */
+  @Nullable Transformation get(final String name, final List<TagPart> inners, final TemplateResolver templateResolver, final Context context);
 
   /**
    * Test if any registered transformation type matches the provided key.
@@ -61,8 +77,23 @@ public interface TransformationRegistry {
    * @param placeholderResolver function to resolve other component types
    * @return whether any transformation exists
    * @since 4.1.0
+   * @deprecated For removal since 4.2.0, use {@link #exists(String, TemplateResolver)} with {@link TemplateResolver#dynamic(Function)}
    */
-  boolean exists(final String name, final Function<String, ComponentLike> placeholderResolver);
+  @ApiStatus.ScheduledForRemoval
+  @Deprecated
+  default boolean exists(final String name, final Function<String, ComponentLike> placeholderResolver) {
+    return this.exists(name, TemplateResolver.dynamic(placeholderResolver));
+  }
+
+  /**
+   * Test if any registered transformation type matches the provided key.
+   *
+   * @param name tag name
+   * @param templateResolver resolver to resolve other component types
+   * @return whether any transformation exists
+   * @since 4.2.0
+   */
+  boolean exists(final String name, final TemplateResolver templateResolver);
 
   /**
    * Creates a new {@link TransformationRegistry.Builder}.

--- a/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistryImpl.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/transformation/TransformationRegistryImpl.java
@@ -26,13 +26,11 @@ package net.kyori.adventure.text.minimessage.transformation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.Template;
 import net.kyori.adventure.text.minimessage.parser.ParsingException;
 import net.kyori.adventure.text.minimessage.parser.node.TagPart;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.text.minimessage.transformation.inbuild.TemplateTransformation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -84,22 +82,19 @@ final class TransformationRegistryImpl implements TransformationRegistry {
   }
 
   @Override
-  public @Nullable Transformation get(final String name, final List<TagPart> inners, final Map<String, Template> templates, final Function<String, ComponentLike> placeholderResolver, final Context context) {
+  public @Nullable Transformation get(final String name, final List<TagPart> inners, final TemplateResolver templateResolver, final Context context) {
     // first try if we have a custom placeholder resolver
-    final ComponentLike potentialTemplate = placeholderResolver.apply(name);
-    if (potentialTemplate != null) {
-      return this.tryLoad(new TemplateTransformation(new Template.ComponentTemplate(name, potentialTemplate.asComponent())), name, inners, context);
+    final Template template = templateResolver.resolve(name);
+    if (template != null) {
+      // The parser handles StringTemplates
+      if (template instanceof Template.ComponentTemplate) {
+        return this.tryLoad(new TemplateTransformation(new Template.ComponentTemplate(name, ((Template.ComponentTemplate) template).value())), name, inners, context);
+      }
     }
     // then check our registry
     for (final TransformationType<? extends Transformation> type : this.types) {
       if (type.canParse.test(name)) {
         return this.tryLoad(type.parser.parse(), name, inners, context);
-      } else if (templates.containsKey(name)) {
-        final Template template = templates.get(name);
-        // The parser handles StringTemplates
-        if (template instanceof Template.ComponentTemplate) {
-          return this.tryLoad(new TemplateTransformation((Template.ComponentTemplate) template), name, inners, context);
-        }
       }
     }
 
@@ -107,9 +102,9 @@ final class TransformationRegistryImpl implements TransformationRegistry {
   }
 
   @Override
-  public boolean exists(final String name, final Function<String, ComponentLike> placeholderResolver) {
+  public boolean exists(final String name, final TemplateResolver templateResolver) {
     // first check the placeholder resolver
-    if (placeholderResolver.apply(name) != null) {
+    if (templateResolver.canResolve(name)) {
       return true;
     }
     // then check registry

--- a/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/ClickTransformation.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/ClickTransformation.java
@@ -26,12 +26,16 @@ package net.kyori.adventure.text.minimessage.transformation.inbuild;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.minimessage.Template;
 import net.kyori.adventure.text.minimessage.Tokens;
 import net.kyori.adventure.text.minimessage.parser.ParsingException;
 import net.kyori.adventure.text.minimessage.parser.node.TagPart;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import net.kyori.adventure.text.minimessage.transformation.Transformation;
 import net.kyori.adventure.text.minimessage.transformation.TransformationParser;
 import net.kyori.examination.ExaminableProperty;
@@ -43,6 +47,8 @@ import org.jetbrains.annotations.NotNull;
  * @since 4.1.0
  */
 public final class ClickTransformation extends Transformation {
+  private static final Pattern TEMPLATE_PATTERN = Pattern.compile("<(.+?)>");
+
   private ClickEvent.Action action;
   private String value;
 
@@ -66,7 +72,22 @@ public final class ClickTransformation extends Transformation {
 
     if (args.size() == 2) {
       this.action = ClickEvent.Action.NAMES.value(args.get(0).value().toLowerCase(Locale.ROOT));
-      this.value = args.get(1).value();
+
+      final String value = args.get(1).value();
+      final Matcher matcher = TEMPLATE_PATTERN.matcher(value);
+      final StringBuffer buffer = new StringBuffer(value.length());
+      final TemplateResolver resolver = this.context.templateResolver();
+      while (matcher.find()) {
+        final String match = matcher.group(1);
+        final Template template = resolver.resolve(match);
+
+        if (template instanceof Template.StringTemplate) {
+          matcher.appendReplacement(buffer, ((Template.StringTemplate) template).value());
+        }
+      }
+      matcher.appendTail(buffer);
+
+      this.value = buffer.toString();
     } else {
       throw new ParsingException("Don't know how to turn " + args + " into a click event", this.argTokenArray());
     }

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.junit.jupiter.api.Test;
@@ -1261,5 +1262,17 @@ public class MiniMessageParserTest extends TestBase {
   @Test
   void testPlaceholderInsidePlaceholder() {
     this.assertParsedEquals(text("meow"), "<sound>", "sound", "<cat>", "cat", "meow");
+  }
+
+  // GH-143
+  @Test
+  void testStringPlaceholderInClickEvent() {
+    final String input = "<click:run_command:'say <sound>'>Click me!";
+    final Component expected = text()
+            .content("Click me!")
+            .clickEvent(ClickEvent.runCommand("say meow"))
+            .build();
+
+    this.assertParsedEquals(expected, input, "sound", "meow");
   }
 }

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageTest.java
@@ -233,7 +233,7 @@ public class MiniMessageTest extends TestBase {
 
   @Test
   void testUnbalancedPlaceholders() {
-    final String expected = "Argument 1 in placeholders is a value, must be Component or String, was java.lang.Integer";
+    final String expected = "Argument 1 in pairs must be a String or ComponentLike value, was java.lang.Integer";
     assertEquals(expected, assertThrows(IllegalArgumentException.class, () -> MiniMessage.get().parse("<a>", "a", 2)).getMessage());
   }
 


### PR DESCRIPTION
This PR implements a `TransformationResolver` which, on the surface, is a simple `String` to `Template` function.
Every internal system has been changed to use this interface which reduces a ridiculous amount of duplicated code throughout the codebase.

Additionally, all of the `parse` methods have been replaced with a single method that accepts a `TransformationResolver`.
Alternatives have been provided for all of the existing `parse` methods through static constructor methods on `TransformationResolver`.

This PR also includes a rather hacky fix for #143 using this new resolver system and is based on top of #142 because I don't want to put the effort into splitting it if this isn't something that is going to get implemented.