### PR TITLE
Improve font transformation control flow

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/FontTransformation.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/transformation/inbuild/FontTransformation.java
@@ -65,17 +65,15 @@ public final class FontTransformation extends Transformation {
     super.load(name, args);
 
     if (args.size() == 1) {
-      @Subst("minecraft:empty") final String fontKey = args.get(0).value();
+      @Subst("empty") final String fontKey = args.get(0).value();
       this.font = Key.key(fontKey);
+    } else if (args.size() == 2) {
+      @Subst(Key.MINECRAFT_NAMESPACE) final String namespaceKey = args.get(0).value();
+      @Subst("empty") final String fontKey = args.get(1).value();
+      this.font = Key.key(namespaceKey, fontKey);
+    } else {
+      throw new ParsingException("Don't know how to turn " + args + " into a font", this.argTokenArray());
     }
-
-    if (args.size() != 2) {
-      throw new ParsingException("Doesn't know how to turn " + args + " into a click event", this.argTokenArray());
-    }
-
-    @Subst(Key.MINECRAFT_NAMESPACE) final String namespaceKey = args.get(0).value();
-    @Subst("empty") final String fontKey = args.get(1).value();
-    this.font = Key.key(namespaceKey, fontKey);
   }
 
   @Override

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -1112,6 +1112,19 @@ public class MiniMessageParserTest extends TestBase {
     this.assertParsedEquals(expected, input);
   }
 
+  @Test
+  void testFontNoNamespace() {
+    final String input = "Nothing <font:uniform>Uniform <font:alt>Alt  </font> Uniform";
+    final Component expected = text("Nothing ")
+        .append(empty().style(s -> s.font(key("uniform")))
+            .append(text("Uniform "))
+            .append(text("Alt  ").style(s -> s.font(key("alt"))))
+            .append(text(" Uniform"))
+        );
+
+    this.assertParsedEquals(expected, input);
+  }
+
   // GH-37
   @Test
   void testPhil() {

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -1113,6 +1113,19 @@ public class MiniMessageParserTest extends TestBase {
   }
 
   @Test
+  void testCustomFont() {
+    final String input = "Default <font:myfont:best_font>Custom font <font:custom:worst_font>Another custom font </font>Back to previous font";
+    final Component expected = text("Default ")
+        .append(empty().style(s -> s.font(key("myfont", "best_font")))
+            .append(text("Custom font "))
+            .append(text("Another custom font ").style(s -> s.font(key("custom", "worst_font"))))
+            .append(text("Back to previous font"))
+        );
+
+    this.assertParsedEquals(expected, input);
+  }
+
+  @Test
   void testFontNoNamespace() {
     final String input = "Nothing <font:uniform>Uniform <font:alt>Alt  </font> Uniform";
     final Component expected = text("Nothing ")


### PR DESCRIPTION
same as #154 except i totally fucked up the branches and i don't know what happened

Changes the control flow in font parsing to something that makes a little more sense

Permits non-namespaced font keys with implicit `minecraft:` (which aren't the best practice but seemed to have had an incomplete code path for it anyway), plus tests for those non-namespaced keys.
**ALSO, fonts aren't click events :(**