### PR TITLE
Lift "parent node is root" out of the while loop.

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/parser/TokenParser.java
@@ -418,13 +418,12 @@ public final class TokenParser {
             }
 
             parentNode = parentNode.parent();
-
-            if (parentNode == null || parentNode instanceof RootNode) {
-              // This means the closing tag didn't match to anything
-              // Since open tags which don't match to anything is never an error, neither is this
-              node.addChild(new TextNode(node, token, message));
-              break;
-            }
+          }
+          if (parentNode == null || parentNode instanceof RootNode) {
+            // This means the closing tag didn't match to anything
+            // Since open tags which don't match to anything is never an error, neither is this
+            node.addChild(new TextNode(node, token, message));
+            break;
           }
           break; // CLOSE_TAG
       }

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -1540,6 +1540,7 @@ public class MiniMessageParserTest extends TestBase {
     this.assertParsedEquals(expected2, input2);
   }
 
+  // https://github.com/KyoriPowered/adventure-text-minimessage/issues/165
   @Test
   void testClosingTagAtRootLevel() {
     final String input = "one</blue>two";

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -1539,4 +1539,13 @@ public class MiniMessageParserTest extends TestBase {
     this.assertParsedEquals(expected1, input1);
     this.assertParsedEquals(expected2, input2);
   }
+
+  @Test
+  void testClosingTagAtRootLevel() {
+    final String input = "one</blue>two";
+
+    final Component expected = text("one</blue>two");
+
+    this.assertParsedEquals(expected, input);
+  }
 }


### PR DESCRIPTION
This way it also matches if the loop never runs (already at root level).

Also adds a test for it. Tests for unmatched closing tags NOT at root level already existed

Fixes #165 