### PR TITLE
Don't check if TagPart is a tag if it's clearly too short

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TagPart.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/parser/node/TagPart.java
@@ -84,6 +84,7 @@ public final class TagPart {
   }
 
   private static boolean isTag(final @NotNull String text) {
+    if (text.length() < 3) return false;
     return text.charAt(0) == '<' || text.charAt(text.length() - 1) == '>';
   }
 

--- a/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
+++ b/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageParserTest.java
@@ -1539,4 +1539,16 @@ public class MiniMessageParserTest extends TestBase {
     this.assertParsedEquals(expected1, input1);
     this.assertParsedEquals(expected2, input2);
   }
+
+  // https://github.com/KyoriPowered/adventure-text-minimessage/issues/166
+  @Test
+  void testEmptyTagPart() {
+    final String input = "<hover:show_text:\"\">text</hover>";
+    final String input2 = "<hover:show_text:>text</hover>";
+
+    final Component expected = text("text").hoverEvent(showText(empty()));
+
+    this.assertParsedEquals(expected, input);
+    this.assertParsedEquals(expected, input2);
+  }
 }


### PR DESCRIPTION
Prevents a StringIndexOutOfBoundsException, also adds a test for it (from the original issue)

Fixes #166 