### PR TITLE
Remove unused protected Transformation::merge method.

### DIFF
--- a/src/main/java/net/kyori/adventure/text/minimessage/transformation/Transformation.java
+++ b/src/main/java/net/kyori/adventure/text/minimessage/transformation/Transformation.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.text.minimessage.transformation;
 
 import java.util.List;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.parser.Token;
 import net.kyori.adventure.text.minimessage.parser.node.TagPart;
@@ -128,20 +127,4 @@ public abstract class Transformation implements Examinable {
 
   @Override
   public abstract int hashCode();
-
-  protected Component merge(final Component target, final Component template) {
-    Component result = target.style(target.style().merge(template.style(), Style.Merge.Strategy.IF_ABSENT_ON_TARGET, Style.Merge.all()));
-
-    if (template.hoverEvent() != null) {
-      result = result.hoverEvent(template.hoverEvent());
-    }
-    if (template.clickEvent() != null) {
-      result = result.clickEvent(template.clickEvent());
-    }
-    if (template.insertion() != null) {
-      result = result.insertion(template.insertion());
-    }
-
-    return result;
-  }
 }


### PR DESCRIPTION
Seems to be leftover from a while ago and the same purpose is fulfilled by just mergeStyle. Plus I couldn't find a single reference to it in this project